### PR TITLE
Compatibility with dplyr 1.1.0

### DIFF
--- a/R/export_as_rdf.R
+++ b/R/export_as_rdf.R
@@ -108,7 +108,7 @@ export_as_rdf <- function(ontology, filename) {
                 object = make_resource(namespaces["skos"], "ConceptScheme")
             )
             # ignore if Obj == NULL or ""
-            if (!is.na(na_if(sources[i, "label"], ""))) {
+            if (!is.na(na_if(sources[[i, "label"]], ""))) {
                 rdf %>% rdf_add(
                     subject = make_resource(sources[i, "uri_prefix"], ""),
                     predicate = make_resource(namespaces["skos"], "prefLabel"),
@@ -117,7 +117,7 @@ export_as_rdf <- function(ontology, filename) {
                 )
             }
             # ignore if Obj == NULL or ""
-            if (!is.na(na_if(sources[i, "description"], ""))) {
+            if (!is.na(na_if(sources[[i, "description"]], ""))) {
                 rdf %>% rdf_add(
                     subject = make_resource(sources[i, "uri_prefix"], ""),
                     predicate = make_resource(namespaces["skos"], "definition"),
@@ -126,7 +126,7 @@ export_as_rdf <- function(ontology, filename) {
                 )
             }
             # ignore if Obj == NULL or ""
-            if (!is.na(na_if(sources[i, "notes"], ""))) {
+            if (!is.na(na_if(sources[[i, "notes"]], ""))) {
                 rdf %>% rdf_add(
                     subject = make_resource(sources[i, "uri_prefix"], ""),
                     predicate = make_resource(namespaces["skos"], "note"),
@@ -135,7 +135,7 @@ export_as_rdf <- function(ontology, filename) {
                 )
             }
             # ignore if Obj == NULL or ""
-            if (!is.na(na_if(sources[i, "license"], ""))) {
+            if (!is.na(na_if(sources[[i, "license"]], ""))) {
                 rdf %>% rdf_add(
                     subject = make_resource(sources[i, "uri_prefix"], ""),
                     predicate = make_resource(namespaces["dct"], "license"),
@@ -191,7 +191,7 @@ export_as_rdf <- function(ontology, filename) {
             objectType = "uri"
         )
         # ignore if Obj == NULL or ""
-        if (!is.na(na_if(harmonised_classes[i, "label"], ""))) {
+        if (!is.na(na_if(harmonised_classes[[i, "label"]], ""))) {
             rdf %>% rdf_add(
                 subject = sub,
                 predicate = make_resource(namespaces["skos"], "prefLabel"),
@@ -199,7 +199,7 @@ export_as_rdf <- function(ontology, filename) {
                 objectType = "literal"
             )
         }
-        if (!is.na(na_if(harmonised_classes[i, "description"], ""))) {
+        if (!is.na(na_if(harmonised_classes[[i, "description"]], ""))) {
             rdf %>% rdf_add(
                 subject = sub,
                 predicate = make_resource(namespaces["skos"], "definition"),
@@ -208,7 +208,7 @@ export_as_rdf <- function(ontology, filename) {
             )
         }
         # semantic relations (skos:broader & skos:narrower)
-        if (!is.na(na_if(harmonised_classes[i, "has_broader"], ""))) {
+        if (!is.na(na_if(harmonised_classes[[i, "has_broader"]], ""))) {
             broader <- paste0("class-", URLencode(harmonised_classes[i, "has_broader"], FALSE))
             rdf %>% rdf_add(
                 subject = sub,
@@ -241,7 +241,7 @@ export_as_rdf <- function(ontology, filename) {
 
         # skos mapping relations
         for (mapping_relation in names(mapping_relations)) {
-            if (!is.na(na_if(harmonised_classes[i, mapping_relations[mapping_relation]], ""))) {
+            if (!is.na(na_if(harmonised_classes[[i, mapping_relations[mapping_relation]]], ""))) {
                 mappings_certainty <- str_split(pull(ontology@classes$harmonised[i, mapping_relations[mapping_relation]]), pattern = " [|] ")
                 for (mapping in mappings_certainty[[1]]) {
                     matched_class_id <- URLencode(str_split(mapping, pattern = "[.]")[[1]][1], FALSE)
@@ -285,7 +285,7 @@ export_as_rdf <- function(ontology, filename) {
                 objectType = "uri"
             )
             # ignore if Obj == NULL or ""
-            if (!is.na(na_if(external_classes[i, "label"], ""))) {
+            if (!is.na(na_if(external_classes[[i, "label"]], ""))) {
                 rdf %>% rdf_add(
                     subject = sub,
                     predicate = make_resource(namespaces["skos"], "prefLabel"),
@@ -293,7 +293,7 @@ export_as_rdf <- function(ontology, filename) {
                     objectType = "literal"
                 )
             }
-            if (!is.na(na_if(external_classes[i, "description"], ""))) {
+            if (!is.na(na_if(external_classes[[i, "description"]], ""))) {
                 rdf %>% rdf_add(
                     subject = sub,
                     predicate = make_resource(namespaces["skos"], "definition"),
@@ -321,7 +321,7 @@ export_as_rdf <- function(ontology, filename) {
             objectType = "uri"
         )
         # ignore if Obj == NULL or ""
-        if (!is.na(na_if(ontology@concepts$harmonised[i, "label"], ""))) {
+        if (!is.na(na_if(ontology@concepts$harmonised[[i, "label"]], ""))) {
             rdf %>% rdf_add(
                 subject = sub,
                 predicate = make_resource(namespaces["skos"], "prefLabel"),
@@ -329,7 +329,7 @@ export_as_rdf <- function(ontology, filename) {
                 objectType = "literal"
             )
         }
-        if (!is.na(na_if(ontology@concepts$harmonised[i, "description"], ""))) {
+        if (!is.na(na_if(ontology@concepts$harmonised[[i, "description"]], ""))) {
             rdf %>% rdf_add(
                 subject = sub,
                 predicate = make_resource(namespaces["skos"], "definition"),
@@ -337,7 +337,7 @@ export_as_rdf <- function(ontology, filename) {
                 objectType = "literal"
             )
         }
-        if (!is.na(na_if(ontology@concepts$harmonised[i, "class"], ""))) {
+        if (!is.na(na_if(ontology@concepts$harmonised[[i, "class"]], ""))) {
             rdf %>% rdf_add(
                 subject = sub,
                 predicate = make_resource(namespaces["rdf"], "type"),
@@ -346,7 +346,7 @@ export_as_rdf <- function(ontology, filename) {
             )
         }
         # semantic relations (skos:broader and skos:narrower)
-        if (!is.na(na_if(ontology@concepts$harmonised[i, "has_broader"], ""))) {
+        if (!is.na(na_if(ontology@concepts$harmonised[[i, "has_broader"]], ""))) {
             broader <- paste0("concept-", ontology@concepts$harmonised[i, "has_broader"])
             rdf %>% rdf_add(
                 subject = sub,
@@ -378,7 +378,7 @@ export_as_rdf <- function(ontology, filename) {
         }
         # skos mapping relations
         for (mapping_relation in names(mapping_relations)) {
-            if (!is.na(na_if(ontology@concepts$harmonised[i, mapping_relations[mapping_relation]], ""))) {
+            if (!is.na(na_if(ontology@concepts$harmonised[[i, mapping_relations[mapping_relation]]], ""))) {
                 mappings_certainty <- str_split(pull(ontology@concepts$harmonised[i, mapping_relations[mapping_relation]]), pattern = " [|] ")
                 for (mapping in mappings_certainty[[1]]) {
                     matched_concept_id <- str_split(mapping, pattern = "[.]")[[1]][1]
@@ -423,7 +423,7 @@ export_as_rdf <- function(ontology, filename) {
             # ignore if Obj == NULL or ""
             # the label col contains the external concept id, whcih is used to build the `sub`.
             # -> effectively there is no label, currently.
-            # if (!is.na(na_if(ontology@concepts$external[i, "label"], ""))) {
+            # if (!is.na(na_if(ontology@concepts$external[[i, "label"]], ""))) {
             #     rdf %>% rdf_add(
             #         subject = sub,
             #         predicate = make_resource(namespaces["skos"], "prefLabel"),
@@ -431,7 +431,7 @@ export_as_rdf <- function(ontology, filename) {
             #         objectType = "literal"
             #     )
             # }
-            if (!is.na(na_if(ontology@concepts$external[i, "description"], ""))) {
+            if (!is.na(na_if(ontology@concepts$external[[i, "description"]], ""))) {
                 rdf %>% rdf_add(
                     subject = sub,
                     predicate = make_resource(namespaces["skos"], "definition"),

--- a/R/new_mapping.R
+++ b/R/new_mapping.R
@@ -255,7 +255,7 @@ new_mapping <- function(new = NULL, target, source = NULL, lut = NULL,
       pivot_wider(id_cols = all_of(targetCols), names_from = match, values_from = newid)
 
     toOut <- toOut %>%
-      na_if(y = "") %>%
+      mutate(across(where(is.character), function(x) na_if(x, ""))) %>%
       select(all_of(targetCols), description, has_close_match, has_broader_match, has_narrower_match, has_exact_match) %>%
       arrange(id)
 
@@ -282,3 +282,5 @@ new_mapping <- function(new = NULL, target, source = NULL, lut = NULL,
   return(out)
 
 }
+
+utils::globalVariables("where")


### PR DESCRIPTION
In dplyr 1.1.0, `na_if()` now requires compatible vectors. In particular, data frames and atomic vectors are not compatible. This PR fixes errors caused by this behaviour change.

We plan to release dplyr on January 27. A pre-emptive fix release of ontologics would be helpful, if possible. Thanks!